### PR TITLE
Update exclude facet icon visibility

### DIFF
--- a/scss/components/search/_facet.scss
+++ b/scss/components/search/_facet.scss
@@ -45,3 +45,10 @@ prm-facet-range {
     padding-left: 1em;
   }
 }
+
+// Don't show the exclude facet icons in the medium breakpoint
+@media (min-width:960px) {
+  .available-facets .section-content .md-chips .md-chip .button-exclude {
+    opacity: 0 !important;
+  }
+}


### PR DESCRIPTION
Don't show the "exclude" icon at the "medium" breakpoint. (This was
a change in the February 2022 release.)